### PR TITLE
Assign tech tokens to first factions after the storm without a token

### DIFF
--- a/src/main/java/controller/commands/CommandManager.java
+++ b/src/main/java/controller/commands/CommandManager.java
@@ -692,8 +692,14 @@ public class CommandManager extends ListenerAdapter {
             if (!techTokens.isEmpty()) {
                 Collections.shuffle(techTokens);
                 for (int i = 0; i < techTokens.size(); i++) {
-                    Faction faction = gameState.getFactions().get((Math.ceilDiv(gameState.getStorm(), 3) - 1 + i) % 6);
-                    faction.getTechTokens().add(techTokens.get(i));
+                    int firstFactionIndex = (Math.ceilDiv(gameState.getStorm(), 3) + i) % 6;
+                    for (int j = 0; j < 6; j++) {
+                        Faction faction = gameState.getFactions().get((firstFactionIndex + j) % 6);
+                        if (faction.getTechTokens().isEmpty()) {
+                            faction.getTechTokens().add(techTokens.get(i));
+                            break;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This corrects the indexing problem and also prevents Fremen, Tleilaxu, and Ix from being given a second token.

It does leave the hard coded 6 as number of factions and adds another instance. RunCommands calculates first after the storm by size of the factions list. But there's probably more to be done to support games with a different number of players than 6.