### PR TITLE
Prevent repeated first bidders

### DIFF
--- a/src/main/java/controller/commands/RunCommands.java
+++ b/src/main/java/controller/commands/RunCommands.java
@@ -414,6 +414,10 @@ public class RunCommands {
             bidOrder.add(bidOrder.remove(0));
         }
 
+        while (gameState.getFaction(bidOrder.get(0)).getHandLimit() <= gameState.getFaction(bidOrder.get(0)).getTreacheryHand().size()) {
+            bidOrder.add(bidOrder.remove(0));
+        }
+
         gameState.setBidOrder(bidOrder);
     }
 


### PR DESCRIPTION
Rotate the bid order before completing updateBidOrder to ensure the first bidder has room for a card.