### PR TITLE
Call tryBid when player sets auto-pass

### DIFF
--- a/src/main/java/controller/commands/PlayerCommands.java
+++ b/src/main/java/controller/commands/PlayerCommands.java
@@ -61,6 +61,7 @@ public class PlayerCommands {
         Faction player = gameState.getFactions().stream().filter(f -> f.getPlayer().substring(2).replace(">", "").equals(event.getUser().toString().split("=")[1].replace(")", "")))
                 .findFirst().get();
         player.setAutoBid(enabled);
+        tryBid(event, discordGame, gameState, player);
         discordGame.sendMessage("mod-info", player.getEmoji() + " set auto-pass to " + enabled);
     }
 


### PR DESCRIPTION
Bidding edge case arose in D30. Player had bid 3. When their turn came up, the bid was already at 3. Player set auto-pass to True, but bot did not pass for him and proceed.

I think setting auto-pass to True should be sufficient in this case to perform the pass. Player should have to also call pass or set max bid again.

I did not add tryBid to setAutoBidPolicy. Don't see any reason why it would be needed there.