### PR TITLE
Improve eligible bidder handling

### DIFF
--- a/src/main/java/controller/commands/PlayerCommands.java
+++ b/src/main/java/controller/commands/PlayerCommands.java
@@ -96,7 +96,7 @@ public class PlayerCommands {
         } else if (!player.isOutbidAlly() && player.hasAlly() && player.getAlly().equals(game.getBidLeader())) player.setBid("pass");
         else if (player.isUseExactBid()) player.setBid(String.valueOf(player.getMaxBid()));
         else player.setBid(String.valueOf(game.getCurrentBid() + 1));
-        boolean r = RunCommands.createBidMessage(discordGame, game, discordGame.getGame().getBidOrder(), player);
+        boolean r = RunCommands.createBidMessage(discordGame, game, discordGame.getGame().getEligibleBidOrder(), player);
         if (r) return;
         tryBid(event, discordGame, game, game.getFaction(game.getCurrentBidder()));
     }

--- a/src/main/java/controller/commands/RicheseCommands.java
+++ b/src/main/java/controller/commands/RicheseCommands.java
@@ -116,7 +116,7 @@ public class RicheseCommands {
 
         if (bidType.equalsIgnoreCase("Normal")) {
             RunCommands.updateBidOrder(game);
-            List<String> bidOrder = game.getBidOrder();
+            List<String> bidOrder = game.getEligibleBidOrder();
 
             RunCommands.createBidMessage(discordGame, game, bidOrder, game.getFaction(bidOrder.get(bidOrder.size() - 1)));
         } else {

--- a/src/main/java/controller/commands/RunCommands.java
+++ b/src/main/java/controller/commands/RunCommands.java
@@ -319,10 +319,7 @@ public class RunCommands {
 
     public static void bidding(SlashCommandInteractionEvent event, DiscordGame discordGame, Game game) throws ChannelNotFoundException {
         updateBidOrder(game);
-        List<String> bidOrder = game.getBidOrder()
-                .stream()
-                .filter(f -> game.getFaction(f).getHandLimit() > game.getFaction(f).getTreacheryHand().size())
-                .collect(Collectors.toList());
+        List<String> bidOrder = game.getEligibleBidOrder();
 
         if (bidOrder.size() == 0) {
             discordGame.sendMessage("bidding-phase", "All hands are full.");
@@ -384,9 +381,6 @@ public class RunCommands {
         boolean tag = bidOrder.get(bidOrder.size() - 1).equals(currentBidder.getName());
         for (String factionName : bidOrder) {
             Faction f = game.getFaction(factionName);
-            if (game.getFaction(factionName).getHandLimit() <= game.getFaction(factionName).getTreacheryHand().size()) {
-                continue;
-            }
             if (tag) {
                 if (f.getName().equals(game.getBidLeader())) {
                     discordGame.sendMessage("bidding-phase", message.toString());
@@ -421,6 +415,10 @@ public class RunCommands {
             bidOrder = bidOrderFactions.stream().map(Faction::getName).collect(Collectors.toList());
         } else {
             bidOrder = game.getBidOrder();
+            List<String> eligibleBidOrder = game.getEligibleBidOrder();
+            while (!bidOrder.get(0).equalsIgnoreCase(eligibleBidOrder.get(0))) {
+                bidOrder.add(bidOrder.remove(0));
+            }
             bidOrder.add(bidOrder.remove(0));
         }
 

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -7,6 +7,7 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static controller.Initializers.getCSVFile;
 
@@ -175,6 +176,13 @@ public class Game extends GameFactionBase {
 
     public List<String> getBidOrder() {
         return bidOrder;
+    }
+
+    public List<String> getEligibleBidOrder() {
+        return bidOrder
+                .stream()
+                .filter(f -> getFaction(f).getHandLimit() > getFaction(f).getTreacheryHand().size())
+                .collect(Collectors.toList());
     }
 
     public void setBidOrder(List<String> bidOrder) {


### PR DESCRIPTION
This should finally allow players with full hands who discarded to come back in to bidding AND keep them from coming back while still full AND ensure the next player to bid gets tagged.

Right after Leo cleaned up game vs gameState, this does not introduce a bidOrder = game.getElibibleBidOrder() naming mismatch in several places. But I don't really want to lengthen bidOrder to eligibleBidOrder everywhere, and I want to keep the changes simpler for review.